### PR TITLE
Feat/#4 mvp 타임딜 스케줄 설정 방식 변경

### DIFF
--- a/src/main/java/org/pgsg/product/domain/model/Product.java
+++ b/src/main/java/org/pgsg/product/domain/model/Product.java
@@ -72,9 +72,10 @@ public class Product extends BaseEntity {
 
 	//요청 시간 기준으로 타임딜 시간 설정
 	public void setTimeDealSchedule(LocalDateTime end) {
-		validateTimeDealSchedule(LocalDateTime.now(),end);
+		LocalDateTime now = LocalDateTime.now();
+		validateTimeDealSchedule(now,end);
 
-		this.timeDealSchedule=TimeDealSchedule.of(LocalDateTime.now(),end);
+		this.timeDealSchedule=TimeDealSchedule.of(now,end);
 		this.status=ProductStatus.PENDING_RESERVATION;
 	}
 

--- a/src/main/java/org/pgsg/product/domain/model/Product.java
+++ b/src/main/java/org/pgsg/product/domain/model/Product.java
@@ -71,7 +71,7 @@ public class Product extends BaseEntity {
 	}
 
 	//요청 시간 기준으로 타임딜 시간 설정
-	private void setTimeDealSchedule(LocalDateTime end) {
+	public void setTimeDealSchedule(LocalDateTime end) {
 		validateTimeDealSchedule(LocalDateTime.now(),end);
 
 		this.timeDealSchedule=TimeDealSchedule.of(LocalDateTime.now(),end);
@@ -157,7 +157,7 @@ public class Product extends BaseEntity {
 		// 	throw new CustomException("InvalidChangeScheduleException", "startTime");
 		// }
 
-		if(start.isBefore(end.plusMinutes(15)))
+		if(end.isBefore(start.plusMinutes(15)))
 			throw new CustomException("InvalidTimeDealDurationException","end");
 	}
 

--- a/src/main/java/org/pgsg/product/domain/model/Product.java
+++ b/src/main/java/org/pgsg/product/domain/model/Product.java
@@ -47,7 +47,7 @@ public class Product extends BaseEntity {
 
 
 	//상품 생성
-	public static Product create(String name, Integer price, String description, TimeDealSchedule timeDealSchedule) {
+	public static Product create(String name, Integer price, String description/*, TimeDealSchedule timeDealSchedule*/) {
 		validatePrice(price);
 
 		Objects.requireNonNull(name,"상품명이 누락되었습니다.");
@@ -57,8 +57,9 @@ public class Product extends BaseEntity {
 		product.name = name;
 		product.price = price;
 		product.description = description;
-		product.timeDealSchedule = TimeDealSchedule.of(timeDealSchedule.getStartTime(), timeDealSchedule.getEndTime());
-		product.status=ProductStatus.PENDING_RESERVATION;
+		//todo: mvp에선 타임딜 설정을 분리하여 구현하고, 추후 고도화 시 스케줄링 솔루션 적용 시엔 두 방식 다 사용 가능하도록 수정 예정
+		//product.timeDealSchedule = TimeDealSchedule.of(timeDealSchedule.getStartTime(), timeDealSchedule.getEndTime());
+		product.status=ProductStatus.PENDING_SALE;	//todo: mvp를 위해 판매 대기 중으로 설정, 추후 생성 시 분기 등에 의해 결정되도록 수정 예정
 
 		return product;
 	}
@@ -69,6 +70,15 @@ public class Product extends BaseEntity {
 			throw new CustomException("PriceValidateException","price");
 	}
 
+	//요청 시간 기준으로 타임딜 시간 설정
+	private void setTimeDealSchedule(LocalDateTime end) {
+		validateTimeDealSchedule(LocalDateTime.now(),end);
+
+		this.timeDealSchedule=TimeDealSchedule.of(LocalDateTime.now(),end);
+		this.status=ProductStatus.PENDING_RESERVATION;
+	}
+
+	//상태 변경	//todo: 다른 도메인과의 협업 시 status 변경 로직 분리 고려
 	//예약 대기 중 -> 예약 진행 중
 	public void startReserve() {
 		if(!status.equals(ProductStatus.PENDING_RESERVATION))
@@ -126,19 +136,29 @@ public class Product extends BaseEntity {
 			description = newDescription;
 
 		if(newTimeDealSchedule != null)
-			changeTimeDealSchedule(newTimeDealSchedule);
+			changeTimeDealSchedule(newTimeDealSchedule.getStartTime(), newTimeDealSchedule.getEndTime());
 	}
 
 	//타임딜 스케줄 변경
-	public void changeTimeDealSchedule(TimeDealSchedule newSchedule) {
+	public void changeTimeDealSchedule(LocalDateTime newStart, LocalDateTime newEnd) {
 		if(!isUpdatableStatus())
 			throw new CustomException("InvalidStatusException","status");
 
-		if (LocalDateTime.now().isAfter(this.timeDealSchedule.getStartTime().minusHours(1))) {
-			throw new CustomException("InvalidChangeScheduleException", "startTime");
-		}
+		validateTimeDealSchedule(newStart, newEnd);
 
-		this.timeDealSchedule = newSchedule;
+		this.timeDealSchedule = TimeDealSchedule.of(newStart, newEnd);
+	}
+
+	private void validateTimeDealSchedule(LocalDateTime start, LocalDateTime end) {	//todo: 정책적 검증의 경우 추가되는 양에 따라 분리 고려
+		Objects.requireNonNull(start,"시작 시간이 누락되었습니다.");
+		Objects.requireNonNull(end,"종료 시간이 누락되었습니다.");
+
+		// if (LocalDateTime.now().isAfter(start)) {	//todo: mvp 이후 고도화 시 해당 부분 적용 고려
+		// 	throw new CustomException("InvalidChangeScheduleException", "startTime");
+		// }
+
+		if(start.isBefore(end.plusMinutes(15)))
+			throw new CustomException("InvalidTimeDealDurationException","end");
 	}
 
 	private boolean isUpdatableStatus() {

--- a/src/main/java/org/pgsg/product/domain/model/TimeDealSchedule.java
+++ b/src/main/java/org/pgsg/product/domain/model/TimeDealSchedule.java
@@ -32,8 +32,9 @@ public class TimeDealSchedule {
 		Objects.requireNonNull(startTime,"시작 시간이 누락되었습니다.");
 		Objects.requireNonNull(endTime,"종료 시간이 누락되었습니다.");
 
-		if(startTime.isBefore(LocalDateTime.now()))
-			throw new CustomException("StartTimeValidateException","startTime");
+		// if(startTime.isBefore(LocalDateTime.now()))	//todo: 타임딜 스케줄링 고도화 시 사용
+		// 	throw new CustomException("StartTimeValidateException","startTime");
+
 		if (endTime.isBefore(startTime))
 			throw new CustomException("EndTimeValidateException","endTime");
 	}

--- a/src/main/java/org/pgsg/product/domain/model/TimeDealSchedule.java
+++ b/src/main/java/org/pgsg/product/domain/model/TimeDealSchedule.java
@@ -34,7 +34,7 @@ public class TimeDealSchedule {
 
 		if(startTime.isBefore(LocalDateTime.now()))
 			throw new CustomException("StartTimeValidateException","startTime");
-		else if (endTime.isBefore(startTime))
-			throw new CustomException("ScheduleValidateException","endTime");
+		if (endTime.isBefore(startTime))
+			throw new CustomException("EndTimeValidateException","endTime");
 	}
 }

--- a/src/main/resources/application-error-product.yml
+++ b/src/main/resources/application-error-product.yml
@@ -10,7 +10,7 @@ error:
       message: "상품가격은 0보다 커야합니다."
       status: 400
 
-    ScheduleValidateException:
+    EndTimeValidateException:
       code: "P003"
       message: "종료 시간은 시작 시간 이후여야 합니다."
       status: 400
@@ -28,4 +28,9 @@ error:
     InvalidChangeScheduleException:
       code: "P006"
       message: "이미 시작되었거나 종료된 예약은 스케줄을 변경할 수 없습니다."
+      status: 409
+
+    InvalidTimeDealDurationException:
+      code: "P007"
+      message: "종료 시간은 시작 시간보다 최소 15분 이후로 설정 가능합니다."
       status: 409

--- a/src/test/java/org/pgsg/product/domain/model/ProductTest.java
+++ b/src/test/java/org/pgsg/product/domain/model/ProductTest.java
@@ -21,14 +21,13 @@ class ProductTest {
 
 	@BeforeEach
 	void setUp() {
-		TimeDealSchedule schedule =TimeDealSchedule.of(LocalDateTime.now().plusHours(2),LocalDateTime.now().plusHours(3));
-		validProduct = Product.create(VALID_PRODUCT_NAME, VALID_PRODUCT_PRICE,VALID_PRODUCT_DESCRIPTION, schedule);
+		validProduct = Product.create(VALID_PRODUCT_NAME, VALID_PRODUCT_PRICE,VALID_PRODUCT_DESCRIPTION);
+		validProduct.setTimeDealSchedule(LocalDateTime.now().plusHours(3));
 	}
 
 	@Test
 	void create_성공() {
-		TimeDealSchedule schedule =TimeDealSchedule.of(LocalDateTime.now().plusHours(2),LocalDateTime.now().plusHours(3));
-		Product p = Product.create(VALID_PRODUCT_NAME, VALID_PRODUCT_PRICE,VALID_PRODUCT_DESCRIPTION, schedule);
+		Product p = Product.create(VALID_PRODUCT_NAME, VALID_PRODUCT_PRICE,VALID_PRODUCT_DESCRIPTION);
 
 		assertThat(p.getName()).isEqualTo(VALID_PRODUCT_NAME);
 		assertThat(p.getPrice()).isEqualTo(VALID_PRODUCT_PRICE);
@@ -37,26 +36,30 @@ class ProductTest {
 
 	@Test
 	void create_잘못된_가격() {
-		TimeDealSchedule schedule =TimeDealSchedule.of(LocalDateTime.now().plusHours(2),LocalDateTime.now().plusHours(3));
 		assertThatThrownBy(()->Product
-			.create(VALID_PRODUCT_NAME, -1,VALID_PRODUCT_DESCRIPTION, schedule))
+			.create(VALID_PRODUCT_NAME, -1,VALID_PRODUCT_DESCRIPTION))
 			.isInstanceOf(CustomException.class);
 	}
 
 	@Test
 	void create_잘못된_종료시간_설정(){
-		assertThatThrownBy(()->Product
-			.create(VALID_PRODUCT_NAME, VALID_PRODUCT_PRICE,VALID_PRODUCT_DESCRIPTION,
-				TimeDealSchedule.of(LocalDateTime.now().plusHours(2),LocalDateTime.now().plusHours(1))))
+		Product p=Product
+			.create(VALID_PRODUCT_NAME, VALID_PRODUCT_PRICE,VALID_PRODUCT_DESCRIPTION);
+		assertThatThrownBy(()->p.setTimeDealSchedule(LocalDateTime.now()))
 			.isInstanceOf(CustomException.class);
 	}
 
+	// @Test	//todo: 해당 부분은 스케줄링 고도화 시 다시 작성
+	// void create_잘못된_시작시간_설정(){
+	// 		assertThatThrownBy(()->Product
+	// 		.create(VALID_PRODUCT_NAME, VALID_PRODUCT_PRICE,VALID_PRODUCT_DESCRIPTION,
+	// 			TimeDealSchedule.of(LocalDateTime.now().minusHours(1),LocalDateTime.now().plusHours(1))))
+	// 		.isInstanceOf(CustomException.class);
+	// }
+
 	@Test
-	void create_잘못된_시작시간_설정(){
-			assertThatThrownBy(()->Product
-			.create(VALID_PRODUCT_NAME, VALID_PRODUCT_PRICE,VALID_PRODUCT_DESCRIPTION,
-				TimeDealSchedule.of(LocalDateTime.now().minusHours(1),LocalDateTime.now().plusHours(1))))
-			.isInstanceOf(CustomException.class);
+	void 타임딜_스케줄링_성공(){
+		assertThat(validProduct.getTimeDealSchedule()).isNotNull();
 	}
 
 	@Test
@@ -95,7 +98,8 @@ class ProductTest {
 		assertThat(validProduct.getName()).isEqualTo(VALID_PRODUCT_NAME);
 		assertThat(validProduct.getPrice()).isEqualTo(VALID_PRODUCT_PRICE);
 		assertThat(validProduct.getDescription()).isEqualTo(VALID_PRODUCT_DESCRIPTION);
-		assertThat(validProduct.getTimeDealSchedule()).isEqualTo(newSchedule);
+		assertThat(validProduct.getTimeDealSchedule().getStartTime()).isEqualTo(newSchedule.getStartTime());
+		assertThat(validProduct.getTimeDealSchedule().getEndTime()).isEqualTo(newSchedule.getEndTime());
 	}
 
 	@Test


### PR DESCRIPTION
### 작업 배경
- mvp 개발 시에는 타임딜 스케줄 설정을 신청 시 바로 타임딜이 시작될 수 있도록 하고, 추후 예약 스케줄링을 실시하는 방식으로 고도화할 수 있도록 변경했습니다.

### 작업 내용
- timeDeal 스케줄 설정과 상품 등록의 분리

### 테스트 여부
- 기존 도메인 테스트에서 변경 부분에 대한 테스트 진행했습니다.

### 기타
- 추후 고도화 시 외부 스케줄링 솔루션 도입 후 해당 방식을 대체하거나 두 가지 방식 다 가능하도록 하는 방향으로 수정할 예정입니다.

### 이슈
> This closes #4 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **주요 변경사항**
  * 상품 생성 흐름 변경: 타임딜 스케줄을 생성 시점이 아닌 별도 단계에서 설정하도록 변경되었습니다.
  * 스케줄 설정 방식 개선: 스케줄은 현재 시점을 시작으로 자동 설정되며 시작/종료 시간을 직접 지정할 수 있습니다.
  * 상태 자동 전환: 스케줄 설정 시 상품 상태가 적절히 업데이트됩니다.

* **검증·오류**
  * 타임딜 기간 검증 강화: 종료는 시작 후 최소 15분 이후여야 하며 위반 시 오류 반환합니다.
  * 시작시간 검증 완화: 과거 시작 시간 관련 일부 제약이 완화되었습니다.

* **테스트**
  * 테스트가 새 스케줄 설정 흐름에 맞게 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->