### PR TITLE
Feat/#22 timedeal scheduler

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'io.micrometer:micrometer-registry-prometheus'
 
+    implementation 'org.springframework.boot:spring-boot-starter-quartz'
+
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     annotationProcessor 'org.mapstruct:mapstruct-processor:1.6.0'

--- a/src/main/java/org/pgsg/product/application/dto/command/CreateProductCommand.java
+++ b/src/main/java/org/pgsg/product/application/dto/command/CreateProductCommand.java
@@ -2,6 +2,7 @@ package org.pgsg.product.application.dto.command;
 
 import static org.pgsg.product.global.exception.ProductErrorCode.*;
 
+import java.time.LocalDateTime;
 import java.util.Objects;
 
 import org.pgsg.common.exception.CustomException;
@@ -9,11 +10,15 @@ import org.pgsg.common.exception.CustomException;
 public record CreateProductCommand(
 	String name,
 	Integer price,
-	String description
+	String description,
+	LocalDateTime startTime,
+	LocalDateTime endTime
 ) {
 	public CreateProductCommand {
 		Objects.requireNonNull(name, "상품명은 필수입니다.");
 		Objects.requireNonNull(price,"가격은 필수입니다.");
+		Objects.requireNonNull(startTime, "타임딜 시작 시간은 필수입니다.");
+		Objects.requireNonNull(endTime, "타임딜 종료 시간은 필수입니다.");
 
 		if(name.isBlank())
 			throw new CustomException(ProductNameValidException,"name");

--- a/src/main/java/org/pgsg/product/application/dto/command/UpdateProductCommand.java
+++ b/src/main/java/org/pgsg/product/application/dto/command/UpdateProductCommand.java
@@ -9,16 +9,10 @@ import org.pgsg.common.exception.CustomException;
 public record UpdateProductCommand(
 	String name,
 	Integer price,
-	String description,
-	LocalDateTime startTime,
-	LocalDateTime endTime
+	String description
 ) {
 	public UpdateProductCommand {
 		if(price!=null&&price<0)
 			throw new CustomException(PriceValidateException,"price");
-
-		if(startTime!=null && endTime!=null
-			&&endTime.isBefore(startTime.plusMinutes(15)))
-			throw new CustomException(InvalidTimeDealDurationException,"end");
 	}
 }

--- a/src/main/java/org/pgsg/product/application/dto/command/UpdateTimeDealCommand.java
+++ b/src/main/java/org/pgsg/product/application/dto/command/UpdateTimeDealCommand.java
@@ -20,6 +20,6 @@ public record UpdateTimeDealCommand(
 			throw new CustomException(InvalidChangeScheduleException, "startTime");
 
 		if (endTime.isBefore(startTime.plusMinutes(15)))
-			throw new CustomException(InvalidTimeDealDurationException, "end");
+			throw new CustomException(InvalidTimeDealDurationException, "endTime");
 	}
 }

--- a/src/main/java/org/pgsg/product/application/dto/command/UpdateTimeDealCommand.java
+++ b/src/main/java/org/pgsg/product/application/dto/command/UpdateTimeDealCommand.java
@@ -1,16 +1,25 @@
 package org.pgsg.product.application.dto.command;
 
+import static org.pgsg.product.global.exception.ProductErrorCode.*;
+
 import java.time.LocalDateTime;
 import java.util.Objects;
 
+import org.pgsg.common.exception.CustomException;
+import org.pgsg.common.exception.ErrorCode;
+
 public record UpdateTimeDealCommand(
-	// LocalDateTime startTime,
+	LocalDateTime startTime,
 	LocalDateTime endTime
 ) {
 	public UpdateTimeDealCommand {
-		Objects.requireNonNull(endTime);
-		//	todo: 고도화 후 작업 예정
-		// if(endTime.isBefore(start.plusMinutes(15)))
-		// 	throw new CustomException(InvalidTimeDealDurationException,"end");
+		Objects.requireNonNull(startTime, "타임딜 시작 시간은 필수입니다.");
+		Objects.requireNonNull(endTime, "타임딜 종료 시간은 필수입니다.");
+
+		if (startTime.isBefore(LocalDateTime.now()))
+			throw new CustomException(InvalidChangeScheduleException, "startTime");
+
+		if (endTime.isBefore(startTime.plusMinutes(15)))
+			throw new CustomException(InvalidTimeDealDurationException, "end");
 	}
 }

--- a/src/main/java/org/pgsg/product/application/service/ProductCommandService.java
+++ b/src/main/java/org/pgsg/product/application/service/ProductCommandService.java
@@ -108,6 +108,7 @@ public class ProductCommandService {
 
 		UUID userId = SecurityUtil.getCurrentUserIdOrThrow();
 		product.deleteProduct(userId);
+		schedulerService.cancelSchedule(id);
 		log.info("상품 삭제. productId:{}, userId:{}", id, userId);
 	}
 

--- a/src/main/java/org/pgsg/product/application/service/ProductCommandService.java
+++ b/src/main/java/org/pgsg/product/application/service/ProductCommandService.java
@@ -2,8 +2,6 @@ package org.pgsg.product.application.service;
 
 import static org.pgsg.product.global.exception.ProductErrorCode.*;
 
-import java.time.LocalDateTime;
-import java.util.Objects;
 import java.util.UUID;
 
 import org.pgsg.common.event.OutboxEvent;
@@ -15,14 +13,11 @@ import org.pgsg.product.application.dto.command.UpdateProductCommand;
 import org.pgsg.product.application.dto.command.UpdateTimeDealCommand;
 import org.pgsg.product.application.dto.result.CreateProductResult;
 import org.pgsg.product.application.dto.result.UpdateProductResult;
-import org.pgsg.product.application.mapper.ProductApplicationMapper;
 import org.pgsg.product.domain.event.ProductCreatedEvent;
 import org.pgsg.product.domain.model.Product;
 import org.pgsg.product.domain.model.TimeDealSchedule;
 import org.pgsg.product.domain.repository.ProductRepository;
-import org.pgsg.product.global.config.TopicConfig;
-import org.pgsg.product.global.exception.ProductErrorCode;
-import org.springframework.context.ApplicationEventPublisher;
+import org.pgsg.product.infrastructure.scheduler.TimeDealSchedulerService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -38,39 +33,31 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class ProductCommandService {
 	private final ProductRepository productRepository;
-	private final ProductApplicationMapper mapper;
-	private final TopicConfig topicConfig;
-	private final ApplicationEventPublisher eventPublisher;
+	private final TimeDealSchedulerService schedulerService;
 
+	/*
+	* 상품 등록
+	* */
 	public CreateProductResult createProduct(CreateProductCommand command) {
 		Product product =Product.create(
-			command.name(),command.price(),command.description());	//todo: 스케줄 입력 시기 변경 후 수정 필요
+			command.name(),command.price(),command.description(),command.startTime(),command.endTime());
 
 		Product saved=productRepository.save(product);
 		log.info("Created product: productId:{}, userId:{}", saved.getId(),saved.getCreatedBy());
-		//todo: 스케줄링 도구 적용 시 생성 후 스케줄이 등록되도록 고도화 예정
+
+		schedulerService.rescheduleTimeDealStart(saved.getId(), saved.getTimeDealSchedule().getStartTime());
+
 		return new CreateProductResult(saved.getId(),saved.getName(),saved.getPrice(),saved.getDescription());
 	}
 
-	public void deleteProduct(UUID id) {
-		Product product=findById(id);
-		checkAuthorization(product.getCreatedBy());
-
-		UUID userId = SecurityUtil.getCurrentUserIdOrThrow();
-		product.deleteProduct(userId);
-		log.info("Deleted product. productId:{}, userId:{}", id, userId);
-	}
-
+	/*
+	* 상품 정보 수정
+	* */
 	public UpdateProductResult updateProduct(UUID id, UpdateProductCommand command) {
 		Product product = findById(id);
 		checkAuthorization(product.getCreatedBy());
 
-		//todo: timeDealSchedule 설정부분 리팩토링 후 수정 예정
-		TimeDealSchedule newSchedule = command.endTime() == null ? null
-			: TimeDealSchedule.of(command.startTime() == null ? LocalDateTime.now() : command.startTime(),
-			command.endTime());
-
-		product.update(command.name(), command.price(), command.description(), newSchedule);
+		product.updateInfo(command.name(), command.price(), command.description());
 
 		Product saved = productRepository.saveAndFlush(product);
 		log.info("Updated product: productId:{}, userId:{}", saved.getId(), saved.getModifiedBy());
@@ -84,57 +71,78 @@ public class ProductCommandService {
 			schedule == null ? null : schedule.getEndTime()
 		);
 	}
-	public UpdateProductResult setTimeDeal(UUID id, UpdateTimeDealCommand command) {
+
+	/*
+	* 타임딜 수정
+	* */
+	public UpdateProductResult updateTimeDeal(UUID id, UpdateTimeDealCommand command) {
 		Product product = findById(id);
 		checkAuthorization(product.getCreatedBy());
 
-		product.setTimeDealSchedule(command.endTime());
+		product.updateTimeDeal(command.startTime(),command.endTime());
 
-		Product saved=productRepository.saveAndFlush(product);
-		log.info("Set Timedeal: productId:{}, userId:{}", saved.getId(), saved.getModifiedBy());
+		Product saved = productRepository.saveAndFlush(product);
+		log.info("타임딜 수정: productId={}, userId={}", saved.getId(), saved.getModifiedBy());
 
-		//todo: mvp 이후 이벤트 발행 위치 변경 예정
-		ProductCreatedEvent payload = mapper.toCreatedEvent(product);
-		String eventType=topicConfig.getProduct().getCreated();
-		OutboxEvent event=new OutboxEvent(saved.getId(),  saved.getId(),"Product", eventType, payload);
-
-		eventPublisher.publishEvent(event);
-		log.info("event is published. productId:{}, eventType:{}", saved.getId(), eventType);
-
+		schedulerService.rescheduleTimeDealStart(saved.getId(), saved.getTimeDealSchedule().getStartTime());
 
 		return new UpdateProductResult(saved.getName(), saved.getPrice(), saved.getDescription(),
 			saved.getTimeDealSchedule().getStartTime(), saved.getTimeDealSchedule().getEndTime());
 	}
 
+
+	/*
+	* 판매 취소 / 삭제
+	* */
 	public void cancelSale(UUID id) {
 		Product product = findById(id);
+		checkAuthorization(product.getCreatedBy());
 		product.cancelSale();
-		log.info("Sale is cancelled. productId:{}", product.getId());
-
-		// UUID userId = /*Objects.requireNonNull(UserContext.getUserId(), "인증 사용자 정보가 없습니다.");*/
-		// 	UUID.fromString("00000000-0000-0000-0000-000000000000");	//todo: 로컬 테스트용, 인증 서비스 연결 후 수정
-		// product.deleteProduct(id);	//todo: 삭제와 판매 취소를 동일하게 할지 좀 더 고려
+		schedulerService.cancelSchedule(id);
+		log.info("판매 취소: productId={}", id);
 	}
+
+	public void deleteProduct(UUID id) {
+		Product product=findById(id);
+		checkAuthorization(product.getCreatedBy());
+
+		UUID userId = SecurityUtil.getCurrentUserIdOrThrow();
+		product.deleteProduct(userId);
+		log.info("상품 삭제. productId:{}, userId:{}", id, userId);
+	}
+
+	/*
+	* 외부 이벤트 수신 핸들러
+	* */
 
 	public void completeTrade(UUID id) {
 		Product product = findById(id);
 		product.complete();
-		log.info("Trade is completed. productId:{}", product.getId());
+		log.info("거래 완료. productId:{}", product.getId());
 	}
 
 	public void completeReservation(UUID id) {
 		Product product = findById(id);
 		product.startTrade();
-		log.info("Reservation is completed. productId:{}", product.getId());
+		log.info("거래 시작. productId:{}", product.getId());
 	}
 
 	public void pendingSale(UUID id) {
 		Product product = findById(id);
 		product.revertToReserving();
-		log.info("This product revert to reserving. productId:{}", product.getId());
+		log.info("판매 대기 전환. productId:{}", product.getId());
+	}
+
+	public void revertToReserving(UUID id) {
+		Product product = findById(id);
+		product.revertToReserving();
+		log.info("예약 진행 복귀: productId={}", id);
 	}
 
 
+	/*
+	* 내부 헬퍼
+	* */
 	private Product findById(UUID productId) {
 		return productRepository.findById(productId)
 			.orElseThrow(()->new CustomException(ProductNotFoundException));

--- a/src/main/java/org/pgsg/product/application/service/ProductCommandService.java
+++ b/src/main/java/org/pgsg/product/application/service/ProductCommandService.java
@@ -14,10 +14,12 @@ import org.pgsg.product.application.dto.command.UpdateTimeDealCommand;
 import org.pgsg.product.application.dto.result.CreateProductResult;
 import org.pgsg.product.application.dto.result.UpdateProductResult;
 import org.pgsg.product.domain.event.ProductCreatedEvent;
+import org.pgsg.product.domain.event.TimeDealScheduleEvent;
 import org.pgsg.product.domain.model.Product;
 import org.pgsg.product.domain.model.TimeDealSchedule;
 import org.pgsg.product.domain.repository.ProductRepository;
 import org.pgsg.product.infrastructure.scheduler.TimeDealSchedulerService;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -34,6 +36,7 @@ import lombok.extern.slf4j.Slf4j;
 public class ProductCommandService {
 	private final ProductRepository productRepository;
 	private final TimeDealSchedulerService schedulerService;
+	private final ApplicationEventPublisher eventPublisher;
 
 	/*
 	* 상품 등록
@@ -45,7 +48,9 @@ public class ProductCommandService {
 		Product saved=productRepository.save(product);
 		log.info("Created product: productId:{}, userId:{}", saved.getId(),saved.getCreatedBy());
 
-		schedulerService.rescheduleTimeDealStart(saved.getId(), saved.getTimeDealSchedule().getStartTime());
+		eventPublisher.publishEvent(
+			new TimeDealScheduleEvent(saved.getId(), saved.getTimeDealSchedule().getStartTime())
+		);
 
 		return new CreateProductResult(saved.getId(),saved.getName(),saved.getPrice(),saved.getDescription());
 	}
@@ -84,7 +89,9 @@ public class ProductCommandService {
 		Product saved = productRepository.saveAndFlush(product);
 		log.info("타임딜 수정: productId={}, userId={}", saved.getId(), saved.getModifiedBy());
 
-		schedulerService.rescheduleTimeDealStart(saved.getId(), saved.getTimeDealSchedule().getStartTime());
+		eventPublisher.publishEvent(
+			new TimeDealScheduleEvent(saved.getId(), saved.getTimeDealSchedule().getStartTime())
+		);
 
 		return new UpdateProductResult(saved.getName(), saved.getPrice(), saved.getDescription(),
 			saved.getTimeDealSchedule().getStartTime(), saved.getTimeDealSchedule().getEndTime());

--- a/src/main/java/org/pgsg/product/domain/event/TimeDealScheduleEvent.java
+++ b/src/main/java/org/pgsg/product/domain/event/TimeDealScheduleEvent.java
@@ -1,0 +1,9 @@
+package org.pgsg.product.domain.event;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record TimeDealScheduleEvent(
+	UUID productId,
+	LocalDateTime startTime
+) {}

--- a/src/main/java/org/pgsg/product/domain/model/Product.java
+++ b/src/main/java/org/pgsg/product/domain/model/Product.java
@@ -48,8 +48,10 @@ public class Product extends BaseEntity {
 	private TimeDealSchedule timeDealSchedule;
 
 
-	//상품 생성
-	public static Product create(String name, Integer price, String description/*, TimeDealSchedule timeDealSchedule*/) {
+	/*
+	상품 생성
+	*/
+	public static Product create(String name, Integer price, String description, LocalDateTime startTime, LocalDateTime endTime) {
 		validatePrice(price);
 
 		Objects.requireNonNull(name,"상품명이 누락되었습니다.");
@@ -59,30 +61,31 @@ public class Product extends BaseEntity {
 		product.name = name;
 		product.price = price;
 		product.description = description;
-		//todo: mvp에선 타임딜 설정을 분리하여 구현하고, 추후 고도화 시 스케줄링 솔루션 적용 시엔 두 방식 다 사용 가능하도록 수정 예정
-		//product.timeDealSchedule = TimeDealSchedule.of(timeDealSchedule.getStartTime(), timeDealSchedule.getEndTime());
-		product.status=ProductStatus.PENDING_SALE;	//todo: mvp를 위해 판매 대기 중으로 설정, 추후 생성 시 분기 등에 의해 결정되도록 수정 예정
+		product.validateTimeDealSchedule(startTime,endTime);
+		product.timeDealSchedule = TimeDealSchedule.of(startTime, endTime);
+		product.status=ProductStatus.PENDING_SALE;
+		product.reserve();
 
 		return product;
 	}
 
-	private static void validatePrice(Integer price) {
-		Objects.requireNonNull(price);
-		if (price < 0)
-			throw new CustomException(PriceValidateException,"price");
+	/*
+	타임딜 스케줄링
+	*/
+	public void updateTimeDeal(LocalDateTime newStart, LocalDateTime newEnd) {
+		if(!isUpdatableStatus())
+			throw new CustomException(InvalidStatusException,"status");
+
+		validateTimeDealSchedule(newStart, newEnd);
+
+		this.timeDealSchedule = TimeDealSchedule.of(newStart, newEnd);
+		if (status == ProductStatus.PENDING_SALE)
+			reserve();
 	}
 
-	//요청 시간 기준으로 타임딜 시간 설정	//todo: 타임딜 스케줄러 도입 후 startReserve 분리 예정
-	public void setTimeDealSchedule(LocalDateTime end) {
-		LocalDateTime now = LocalDateTime.now();
-		validateTimeDealSchedule(now,end);
-
-		this.timeDealSchedule=TimeDealSchedule.of(now,end);
-		this.status=ProductStatus.PENDING_RESERVATION;
-		startReserve();
-	}
-
-	//상태 변경	//todo: 다른 도메인과의 협업 시 status 변경 로직 분리 고려
+	/*
+	상태 전이
+	*/
 	//예약 대기 중 -> 예약 진행 중
 	public void startReserve() {
 		if(!status.equals(ProductStatus.PENDING_RESERVATION))
@@ -123,8 +126,10 @@ public class Product extends BaseEntity {
 		status = ProductStatus.SALE_CANCELED;
 	}
 
-	//상품 정보 변경
-	public void update(String newName, Integer newPrice, String newDescription, TimeDealSchedule newTimeDealSchedule) {
+	/*
+	* 상품 정보 수정
+	* */
+	public void updateInfo(String newName, Integer newPrice, String newDescription) {
 		if(!isUpdatableStatus())
 			throw new CustomException(InvalidStatusException,"status");
 
@@ -138,31 +143,24 @@ public class Product extends BaseEntity {
 
 		if(!(newDescription == null || newDescription.isBlank()))
 			description = newDescription;
-
-		if(newTimeDealSchedule != null)
-			changeTimeDealSchedule(newTimeDealSchedule.getStartTime(), newTimeDealSchedule.getEndTime());
 	}
 
-	//타임딜 스케줄 변경
-	public void changeTimeDealSchedule(LocalDateTime newStart, LocalDateTime newEnd) {
-		if(!isUpdatableStatus())
-			throw new CustomException(InvalidStatusException,"status");
 
-		validateTimeDealSchedule(newStart, newEnd);
 
-		this.timeDealSchedule = TimeDealSchedule.of(newStart, newEnd);
+	/*
+	상품 삭제 - soft delete + 거래 취소로 상태 변경
+	* */
+	public void deleteProduct(UUID userId) {
+		delete(userId);
+		cancelSale();
 	}
 
-	private void validateTimeDealSchedule(LocalDateTime start, LocalDateTime end) {	//todo: 정책적 검증의 경우 추가되는 양에 따라 분리 고려
-		Objects.requireNonNull(start,"시작 시간이 누락되었습니다.");
-		Objects.requireNonNull(end,"종료 시간이 누락되었습니다.");
 
-		// if (LocalDateTime.now().isAfter(start)) {	//todo: mvp 이후 고도화 시 해당 부분 적용 고려
-		// 	throw new CustomException("InvalidChangeScheduleException", "startTime");
-		// }
-
-		if(end.isBefore(start.plusMinutes(15)))
-			throw new CustomException(InvalidTimeDealDurationException,"end");
+	//내부 검증
+	private static void validatePrice(Integer price) {
+		Objects.requireNonNull(price);
+		if (price < 0)
+			throw new CustomException(PriceValidateException,"price");
 	}
 
 	private boolean isUpdatableStatus() {
@@ -170,9 +168,15 @@ public class Product extends BaseEntity {
 			status == ProductStatus.PENDING_SALE;
 	}
 
-	//상품 삭제 - soft delete + 거래 취소로 상태 변경
-	public void deleteProduct(UUID userId) {
-		delete(userId);
-		cancelSale();
+	private void validateTimeDealSchedule(LocalDateTime start, LocalDateTime end) {	//todo: 정책적 검증의 경우 추가되는 양에 따라 분리 고려
+		Objects.requireNonNull(start,"시작 시간이 누락되었습니다.");
+		Objects.requireNonNull(end,"종료 시간이 누락되었습니다.");
+
+		if (LocalDateTime.now().isAfter(start)) {
+			throw new CustomException(InvalidChangeScheduleException, "startTime");
+		}
+
+		if(end.isBefore(start.plusMinutes(15)))
+			throw new CustomException(InvalidTimeDealDurationException,"end");
 	}
 }

--- a/src/main/java/org/pgsg/product/domain/model/TimeDealSchedule.java
+++ b/src/main/java/org/pgsg/product/domain/model/TimeDealSchedule.java
@@ -31,11 +31,11 @@ public class TimeDealSchedule {
 	}
 
 	public void validateTimeDealSchedule() {
-		// Objects.requireNonNull(startTime,"시작 시간이 누락되었습니다.");	//todo: 누락 시 현재 시각으로 설정할 지 고려
+		Objects.requireNonNull(startTime,"시작 시간이 누락되었습니다.");
 		Objects.requireNonNull(endTime,"종료 시간이 누락되었습니다.");
 
-		// if(startTime.isBefore(LocalDateTime.now()))	//todo: 타임딜 스케줄링 고도화 시 사용
-		// 	throw new CustomException("StartTimeValidateException","startTime");
+		if(startTime.isBefore(LocalDateTime.now()))
+			throw new CustomException(StartTimeValidateException,"startTime");
 
 		if (endTime.isBefore(startTime))
 			throw new CustomException(EndTimeValidateException,"endTime");

--- a/src/main/java/org/pgsg/product/infrastructure/scheduler/TimeDealScheduleEventListener.java
+++ b/src/main/java/org/pgsg/product/infrastructure/scheduler/TimeDealScheduleEventListener.java
@@ -1,0 +1,29 @@
+package org.pgsg.product.application.event;
+
+import org.pgsg.product.domain.event.TimeDealScheduleEvent;
+import org.pgsg.product.infrastructure.scheduler.TimeDealSchedulerService;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * DB 커밋 완료 후 Quartz 스케줄을 등록/교체한다.
+ * AFTER_COMMIT 단계에서 실행되므로 트랜잭션 롤백 시 스케줄이 등록되지 않는다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TimeDealScheduleEventListener {
+
+	private final TimeDealSchedulerService schedulerService;
+
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	public void handle(TimeDealScheduleEvent event) {
+		schedulerService.rescheduleTimeDealStart(event.productId(), event.startTime());
+		log.info("타임딜 스케줄 등록 완료 (커밋 후): productId={}, startTime={}",
+			event.productId(), event.startTime());
+	}
+}

--- a/src/main/java/org/pgsg/product/infrastructure/scheduler/TimeDealSchedulerService.java
+++ b/src/main/java/org/pgsg/product/infrastructure/scheduler/TimeDealSchedulerService.java
@@ -2,6 +2,7 @@ package org.pgsg.product.infrastructure.scheduler;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.Date;
 import java.util.UUID;
 
@@ -64,6 +65,7 @@ public class TimeDealSchedulerService {
 			if (scheduler.checkExists(key)) {
 				Trigger newTrigger = TriggerBuilder.newTrigger()
 					.withIdentity(key)
+					.forJob(jobKey(productId))
 					.startAt(toDate(newStartTime))
 					.build();
 
@@ -71,7 +73,18 @@ public class TimeDealSchedulerService {
 				log.info("타임딜 스케줄 수정: productId={}, newStartTime={}", productId, newStartTime);
 			} else {
 				// 스케줄이 없는 경우(예: 이전 실행 완료 후 재설정) 신규 등록
-				scheduleTimeDealStart(productId, newStartTime);
+				Trigger newTrigger = TriggerBuilder.newTrigger()
+					.withIdentity(triggerKey(productId))
+					.forJob(jobKey(productId))
+					.startAt(toDate(newStartTime))
+					.build();
+
+				if (scheduler.checkExists(jobKey(productId))) {
+					scheduler.scheduleJob(newTrigger);  // Job은 유지, Trigger만 신규 등록
+				} else {
+					scheduleTimeDealStart(productId, newStartTime);  // Job + Trigger 모두 신규 등록
+				}
+				log.info("타임딜 스케줄 신규 등록: productId={}, newStartTime={}", productId, newStartTime);
 			}
 
 		} catch (SchedulerException e) {
@@ -89,6 +102,7 @@ public class TimeDealSchedulerService {
 			log.info("타임딜 스케줄 제거: productId={}", productId);
 		} catch (SchedulerException e) {
 			log.warn("타임딜 스케줄 제거 실패 (이미 실행됐을 수 있음): productId={}", productId, e);
+			throw new RuntimeException("타임딜 스케줄 제거 중 오류가 발생했습니다.", e);
 		}
 	}
 
@@ -101,6 +115,6 @@ public class TimeDealSchedulerService {
 	}
 
 	private static Date toDate(LocalDateTime ldt) {
-		return Date.from(ldt.atZone(ZoneId.systemDefault()).toInstant());
+		return Date.from(ldt.toInstant(ZoneOffset.UTC));
 	}
 }

--- a/src/main/java/org/pgsg/product/infrastructure/scheduler/TimeDealSchedulerService.java
+++ b/src/main/java/org/pgsg/product/infrastructure/scheduler/TimeDealSchedulerService.java
@@ -1,0 +1,106 @@
+package org.pgsg.product.infrastructure.scheduler;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+import java.util.UUID;
+
+import org.quartz.JobBuilder;
+import org.quartz.JobDetail;
+import org.quartz.JobKey;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+import org.quartz.Trigger;
+import org.quartz.TriggerBuilder;
+import org.quartz.TriggerKey;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TimeDealSchedulerService {
+
+	private static final String GROUP = "timedeal";
+
+	private final Scheduler scheduler;
+
+	/**
+	 * 상품 등록 시 호출 — startTime에 TimeDealStartJob을 실행할 트리거를 등록한다. -> rescheduleTimeDealStart에 이미 신규 등록 분기가 있으므로 해당 분기에서만 사용
+	 */
+	private void scheduleTimeDealStart(UUID productId, LocalDateTime startTime) {
+		try {
+			JobDetail job = JobBuilder.newJob(TimeDealStartJob.class)
+				.withIdentity(jobKey(productId))
+				.usingJobData("productId", productId.toString())
+				.storeDurably()
+				.build();
+
+			Trigger trigger = TriggerBuilder.newTrigger()
+				.withIdentity(triggerKey(productId))
+				.forJob(job)
+				.startAt(toDate(startTime))
+				.build();
+
+			scheduler.scheduleJob(job, trigger);
+			log.info("타임딜 스케줄 등록: productId={}, startTime={}", productId, startTime);
+
+		} catch (SchedulerException e) {
+			log.error("타임딜 스케줄 등록 실패: productId={}", productId, e);
+			throw new RuntimeException("타임딜 스케줄 등록 중 오류가 발생했습니다.", e);
+		}
+	}
+
+	/**
+	 * 타임딜 수정 시 호출 — 기존 트리거를 새 startTime으로 교체한다.
+	 * 기존 스케줄이 없으면 신규 등록한다.
+	 */
+	public void rescheduleTimeDealStart(UUID productId, LocalDateTime newStartTime) {
+		try {
+			TriggerKey key = triggerKey(productId);
+
+			if (scheduler.checkExists(key)) {
+				Trigger newTrigger = TriggerBuilder.newTrigger()
+					.withIdentity(key)
+					.startAt(toDate(newStartTime))
+					.build();
+
+				scheduler.rescheduleJob(key, newTrigger);
+				log.info("타임딜 스케줄 수정: productId={}, newStartTime={}", productId, newStartTime);
+			} else {
+				// 스케줄이 없는 경우(예: 이전 실행 완료 후 재설정) 신규 등록
+				scheduleTimeDealStart(productId, newStartTime);
+			}
+
+		} catch (SchedulerException e) {
+			log.error("타임딜 스케줄 수정 실패: productId={}", productId, e);
+			throw new RuntimeException("타임딜 스케줄 수정 중 오류가 발생했습니다.", e);
+		}
+	}
+
+	/**
+	 * 판매 취소 등으로 스케줄을 제거할 때 호출한다.
+	 */
+	public void cancelSchedule(UUID productId) {
+		try {
+			scheduler.deleteJob(jobKey(productId));
+			log.info("타임딜 스케줄 제거: productId={}", productId);
+		} catch (SchedulerException e) {
+			log.warn("타임딜 스케줄 제거 실패 (이미 실행됐을 수 있음): productId={}", productId, e);
+		}
+	}
+
+	private static JobKey jobKey(UUID productId) {
+		return JobKey.jobKey("timedeal-" + productId, GROUP);
+	}
+
+	private static TriggerKey triggerKey(UUID productId) {
+		return TriggerKey.triggerKey("trigger-" + productId, GROUP);
+	}
+
+	private static Date toDate(LocalDateTime ldt) {
+		return Date.from(ldt.atZone(ZoneId.systemDefault()).toInstant());
+	}
+}

--- a/src/main/java/org/pgsg/product/infrastructure/scheduler/TimeDealStartJob.java
+++ b/src/main/java/org/pgsg/product/infrastructure/scheduler/TimeDealStartJob.java
@@ -1,0 +1,68 @@
+package org.pgsg.product.infrastructure.scheduler;
+
+import java.util.UUID;
+
+import org.pgsg.common.event.OutboxEvent;
+import org.pgsg.common.exception.CustomException;
+import org.pgsg.product.application.mapper.ProductApplicationMapper;
+import org.pgsg.product.domain.event.ProductCreatedEvent;
+import org.pgsg.product.domain.model.Product;
+import org.pgsg.product.domain.repository.ProductRepository;
+import org.pgsg.product.global.config.TopicConfig;
+import org.pgsg.product.global.exception.ProductErrorCode;
+import org.quartz.Job;
+import org.quartz.JobExecutionContext;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 타임딜 startTime 도달 시 Quartz가 실행하는 Job.
+ * infrastructure 계층에서 domain을 직접 호출하여 역방향 의존 방지.
+ * 1. PENDING_RESERVATION → RESERVING 상태 전이 (startReserve)
+ * 2. Outbox 경유 Kafka 이벤트 발행 (타임딜 시작 알림 — 예약 서비스 구독)
+ * 두 작업이 같은 트랜잭션 내에서 처리되어 상태 전이와 이벤트 발행이 동시에 보장됨.
+ */
+@Slf4j
+@Component
+public class TimeDealStartJob implements Job {
+
+	// Quartz는 Job 인스턴스를 직접 생성하므로 필드 주입 사용
+	@Autowired
+	private ProductRepository productRepository;
+
+	@Autowired
+	private ApplicationEventPublisher eventPublisher;
+
+	@Autowired
+	private TopicConfig topicConfig;
+
+	@Autowired
+	private ProductApplicationMapper mapper;
+
+	@Override
+	@Transactional
+	public void execute(JobExecutionContext context) {
+		UUID productId = UUID.fromString(
+			context.getMergedJobDataMap().getString("productId")
+		);
+
+		Product product = productRepository.findById(productId)
+			.orElseThrow(() -> new CustomException(ProductErrorCode.ProductNotFoundException));
+
+		// 상태 전이: PENDING_RESERVATION → RESERVING
+		product.startReserve();
+		productRepository.save(product);
+
+		// Outbox 경유 이벤트 발행 — 예약 서비스가 구독하여 선착순 접수 시작
+		ProductCreatedEvent payload = mapper.toCreatedEvent(product);
+		String eventType = topicConfig.getProduct().getCreated();
+		OutboxEvent event = new OutboxEvent(productId, productId, "Product", eventType, payload);
+		eventPublisher.publishEvent(event);
+
+		log.info("타임딜 시작: productId={}, eventType={}", productId, eventType);
+	}
+}

--- a/src/main/java/org/pgsg/product/infrastructure/scheduler/TimeDealStartJob.java
+++ b/src/main/java/org/pgsg/product/infrastructure/scheduler/TimeDealStartJob.java
@@ -2,20 +2,11 @@ package org.pgsg.product.infrastructure.scheduler;
 
 import java.util.UUID;
 
-import org.pgsg.common.event.OutboxEvent;
-import org.pgsg.common.exception.CustomException;
-import org.pgsg.product.application.mapper.ProductApplicationMapper;
-import org.pgsg.product.domain.event.ProductCreatedEvent;
-import org.pgsg.product.domain.model.Product;
 import org.pgsg.product.domain.repository.ProductRepository;
-import org.pgsg.product.global.config.TopicConfig;
-import org.pgsg.product.global.exception.ProductErrorCode;
 import org.quartz.Job;
 import org.quartz.JobExecutionContext;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -35,34 +26,13 @@ public class TimeDealStartJob implements Job {
 	private ProductRepository productRepository;
 
 	@Autowired
-	private ApplicationEventPublisher eventPublisher;
-
-	@Autowired
-	private TopicConfig topicConfig;
-
-	@Autowired
-	private ProductApplicationMapper mapper;
+	private TimeDealStartService timeDealStartService;
 
 	@Override
-	@Transactional
 	public void execute(JobExecutionContext context) {
 		UUID productId = UUID.fromString(
 			context.getMergedJobDataMap().getString("productId")
 		);
-
-		Product product = productRepository.findById(productId)
-			.orElseThrow(() -> new CustomException(ProductErrorCode.ProductNotFoundException));
-
-		// 상태 전이: PENDING_RESERVATION → RESERVING
-		product.startReserve();
-		productRepository.save(product);
-
-		// Outbox 경유 이벤트 발행 — 예약 서비스가 구독하여 선착순 접수 시작
-		ProductCreatedEvent payload = mapper.toCreatedEvent(product);
-		String eventType = topicConfig.getProduct().getCreated();
-		OutboxEvent event = new OutboxEvent(productId, productId, "Product", eventType, payload);
-		eventPublisher.publishEvent(event);
-
-		log.info("타임딜 시작: productId={}, eventType={}", productId, eventType);
+		timeDealStartService.startTimeDeal(productId);
 	}
 }

--- a/src/main/java/org/pgsg/product/infrastructure/scheduler/TimeDealStartService.java
+++ b/src/main/java/org/pgsg/product/infrastructure/scheduler/TimeDealStartService.java
@@ -1,0 +1,50 @@
+package org.pgsg.product.infrastructure.scheduler;
+
+import java.util.UUID;
+
+import org.pgsg.common.event.OutboxEvent;
+import org.pgsg.common.exception.CustomException;
+import org.pgsg.product.application.mapper.ProductApplicationMapper;
+import org.pgsg.product.domain.event.ProductCreatedEvent;
+import org.pgsg.product.domain.model.Product;
+import org.pgsg.product.domain.repository.ProductRepository;
+import org.pgsg.product.global.config.TopicConfig;
+import org.pgsg.product.global.exception.ProductErrorCode;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * TimeDealStartJob에서 위임받아 트랜잭션 내에서 상태 전이와 이벤트 발행을 처리한다.
+ * Quartz Job은 Spring 컨텍스트 외부에서 생성되므로 @Transactional이 적용되지 않는다.
+ * 트랜잭션이 필요한 로직은 이 Spring 관리 서비스에 위임한다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TimeDealStartService {
+
+	private final ProductRepository productRepository;
+	private final ApplicationEventPublisher eventPublisher;
+	private final TopicConfig topicConfig;
+	private final ProductApplicationMapper mapper;
+
+	@Transactional
+	public void startTimeDeal(UUID productId) {
+		Product product = productRepository.findById(productId)
+			.orElseThrow(() -> new CustomException(ProductErrorCode.ProductNotFoundException));
+
+		product.startReserve();  // PENDING_RESERVATION → RESERVING
+		productRepository.save(product);
+
+		ProductCreatedEvent payload = mapper.toCreatedEvent(product);
+		String eventType = topicConfig.getProduct().getCreated();
+		OutboxEvent event = new OutboxEvent(productId, productId, "Product", eventType, payload);
+		eventPublisher.publishEvent(event);
+
+		log.info("타임딜 시작: productId={}, eventType={}", productId, eventType);
+	}
+}

--- a/src/main/java/org/pgsg/product/presentation/controller/ProductOuterController.java
+++ b/src/main/java/org/pgsg/product/presentation/controller/ProductOuterController.java
@@ -66,7 +66,7 @@ public class ProductOuterController {
 	@PatchMapping("/{productId}/schedule")
 	public CommonResponse<UpdateProductResponse> setTimeDealSchedule(@PathVariable UUID productId,@Valid @RequestBody UpdateTimeDealRequest request) {
 		UpdateTimeDealCommand command=mapper.toCommand(request);
-		UpdateProductResult result =productCommandService.setTimeDeal(productId, command);
+		UpdateProductResult result =productCommandService.updateTimeDeal(productId, command);
 		UpdateProductResponse response=mapper.toResponse(result);
 		return CommonResponse.success(response);
 	}

--- a/src/main/java/org/pgsg/product/presentation/dto/request/CreateProductRequest.java
+++ b/src/main/java/org/pgsg/product/presentation/dto/request/CreateProductRequest.java
@@ -1,5 +1,7 @@
 package org.pgsg.product.presentation.dto.request;
 
+import java.time.LocalDateTime;
+
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -7,7 +9,8 @@ import jakarta.validation.constraints.NotNull;
 public record CreateProductRequest (
 	@NotBlank String name,
 	@NotNull @Min(value = 0, message = "가격은 0원 이상이어야 합니다.") Integer price,
-	String description
-	//todo: 추후 타임딜 초기 설정을 위해 시작시간/종료시간 추가 예정
+	String description,
+	@NotNull LocalDateTime startTime,
+	@NotNull LocalDateTime endTime
 ){
 }

--- a/src/main/java/org/pgsg/product/presentation/dto/request/UpdateProductRequest.java
+++ b/src/main/java/org/pgsg/product/presentation/dto/request/UpdateProductRequest.java
@@ -7,8 +7,6 @@ import jakarta.validation.constraints.Min;
 public record UpdateProductRequest(
 	String name,
 	@Min(value = 0, message = "가격은 0원 이상이어야 합니다.") Integer price,
-	String description,
-	LocalDateTime startTime,
-	LocalDateTime endTime
+	String description
 ) {
 }

--- a/src/main/java/org/pgsg/product/presentation/dto/request/UpdateTimeDealRequest.java
+++ b/src/main/java/org/pgsg/product/presentation/dto/request/UpdateTimeDealRequest.java
@@ -3,9 +3,10 @@ package org.pgsg.product.presentation.dto.request;
 import java.time.LocalDateTime;
 
 import jakarta.validation.constraints.NotNull;
+import lombok.NonNull;
 
 public record UpdateTimeDealRequest(
-	// LocalDateTime startTime,	//todo: mvp에서는 종료 시간만 설정
+	@NonNull LocalDateTime startTime,
 	@NotNull LocalDateTime endTime
 ) {
 }

--- a/src/main/java/org/pgsg/product/presentation/dto/request/UpdateTimeDealRequest.java
+++ b/src/main/java/org/pgsg/product/presentation/dto/request/UpdateTimeDealRequest.java
@@ -3,10 +3,9 @@ package org.pgsg.product.presentation.dto.request;
 import java.time.LocalDateTime;
 
 import jakarta.validation.constraints.NotNull;
-import lombok.NonNull;
 
 public record UpdateTimeDealRequest(
-	@NonNull LocalDateTime startTime,
+	@NotNull LocalDateTime startTime,
 	@NotNull LocalDateTime endTime
 ) {
 }

--- a/src/test/java/org/pgsg/product/application/service/ProductCommandServiceTest.java
+++ b/src/test/java/org/pgsg/product/application/service/ProductCommandServiceTest.java
@@ -24,41 +24,36 @@ import org.pgsg.config.security.UserDetailsImpl;
 import org.pgsg.product.application.dto.command.CreateProductCommand;
 import org.pgsg.product.application.dto.command.UpdateProductCommand;
 import org.pgsg.product.application.dto.command.UpdateTimeDealCommand;
-import org.pgsg.product.application.mapper.ProductApplicationMapper;
-import org.pgsg.product.domain.event.ProductCreatedEvent;
 import org.pgsg.product.domain.model.Product;
 import org.pgsg.product.domain.model.ProductStatus;
 import org.pgsg.product.domain.repository.ProductRepository;
-import org.pgsg.product.global.config.TopicConfig;
-import org.springframework.context.ApplicationEventPublisher;
+import org.pgsg.product.infrastructure.scheduler.TimeDealSchedulerService;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("Product 서비스 코드 테스트")
 class ProductCommandServiceTest {
+
 	@Mock
 	private ProductRepository productRepository;
+	@Mock
+	private TimeDealSchedulerService schedulerService;
 	@InjectMocks
 	private ProductCommandService productCommandService;
-	@Mock
-	private ProductApplicationMapper mapper;
-	@Mock
-	private TopicConfig topicConfig;
-	@Mock
-	private ApplicationEventPublisher applicationEventPublisher;
 
 	@Captor
 	private ArgumentCaptor<Product> captor;
 
-	private final String PRODUCT_NAME="testName";
-	private final Integer PRICE=100;
-	private final LocalDateTime END_TIME= LocalDateTime.now().plusHours(1);
+	private static final String PRODUCT_NAME = "testName";
+	private static final Integer PRICE = 100;
+	private static final LocalDateTime START_TIME = LocalDateTime.now().plusHours(1);
+	private static final LocalDateTime END_TIME = LocalDateTime.now().plusHours(3);
+
 	private MockedStatic<SecurityUtil> securityUtilMockedStatic;
 
 	@BeforeEach
 	void setUp() {
 		securityUtilMockedStatic = mockStatic(SecurityUtil.class);
-
 		securityUtilMockedStatic.when(SecurityUtil::getCurrentUser)
 			.thenReturn(Optional.of(UserDetailsImpl.builder()
 				.uuid(UUID.randomUUID())
@@ -81,120 +76,114 @@ class ProductCommandServiceTest {
 
 	@Test
 	void createProduct_성공() {
-		//given
-		CreateProductCommand command = new CreateProductCommand(PRODUCT_NAME, PRICE, null);
+		// given
+		CreateProductCommand command = new CreateProductCommand(PRODUCT_NAME, PRICE, null, START_TIME, END_TIME);
 		when(productRepository.save(any(Product.class)))
 			.thenAnswer(invocation -> {
 				Product p = invocation.getArgument(0);
 				ReflectionTestUtils.setField(p, "id", UUID.randomUUID());
-				ReflectionTestUtils.setField(p, "name", PRODUCT_NAME);
-				ReflectionTestUtils.setField(p, "price", PRICE);
 				return p;
 			});
 
-		//when
+		// when
 		productCommandService.createProduct(command);
 
-		//then
+		// then
 		verify(productRepository).save(captor.capture());
-		Product saved=captor.getValue();
+		Product saved = captor.getValue();
 		assertThat(saved.getName()).isEqualTo(PRODUCT_NAME);
 		assertThat(saved.getPrice()).isEqualTo(PRICE);
+		assertThat(saved.getTimeDealSchedule()).isNotNull();
+		assertThat(saved.getStatus()).isEqualTo(ProductStatus.PENDING_RESERVATION);
+
+		// 스케줄 등록 호출 검증
+		verify(schedulerService).rescheduleTimeDealStart(any(UUID.class), eq(START_TIME));
 	}
 
 	@Test
-	void createProduct_실패_잘못된_가격(){
-		assertThatThrownBy(()->productCommandService.createProduct(new CreateProductCommand(PRODUCT_NAME, -1, null)))
-			.isInstanceOf(CustomException.class);
+	void createProduct_실패_잘못된_가격() {
+		assertThatThrownBy(() -> productCommandService.createProduct(
+			new CreateProductCommand(PRODUCT_NAME, -1, null, START_TIME, END_TIME))
+		).isInstanceOf(CustomException.class);
 	}
 
 	@Test
 	void deleteProduct() {
-		//given
-		UUID userId=UUID.randomUUID();
-		Product product = Product.create(PRODUCT_NAME, PRICE, null);
-		securityUtilMockedStatic.when(SecurityUtil::getCurrentUserIdOrThrow).thenReturn(userId);
+		// given
+		UUID userId = UUID.randomUUID();
+		Product product = Product.create(PRODUCT_NAME, PRICE, null, START_TIME, END_TIME);
+		ReflectionTestUtils.setField(product, "createdBy", userId);
+		securityUtilMockedStatic.when(SecurityUtil::getCurrentUserIdOrThrow).thenReturn(userId); // 추가
 		when(productRepository.findById(any(UUID.class))).thenReturn(Optional.of(product));
 
-		//when
+		// when
 		productCommandService.deleteProduct(UUID.randomUUID());
 
-		//then
+		// then
 		assertThat(product.getDeletedBy()).isNotNull();
+		assertThat(product.getStatus()).isEqualTo(ProductStatus.SALE_CANCELED);
+		verify(schedulerService).cancelSchedule(any(UUID.class));
 	}
 
 	@Test
 	void updateInfoProduct() {
-		//given
-		Product product = Product.create(PRODUCT_NAME, PRICE, null);
-		UpdateProductCommand command=new UpdateProductCommand("test",1,null,LocalDateTime.now(),LocalDateTime.now().plusHours(1));
+		// given
+		Product product = Product.create(PRODUCT_NAME, PRICE, null, START_TIME, END_TIME);
+		UpdateProductCommand command = new UpdateProductCommand("newName", 200, "newDesc");
 		when(productRepository.findById(any(UUID.class))).thenReturn(Optional.of(product));
-		when(productRepository.saveAndFlush(any(Product.class))).thenAnswer(invocation -> {
-			Product p = invocation.getArgument(0);
-			ReflectionTestUtils.setField(p, "id", UUID.randomUUID());
-			ReflectionTestUtils.setField(p, "name", PRODUCT_NAME);
-			ReflectionTestUtils.setField(p, "price", PRICE);
-			return p;
-		});
+		when(productRepository.saveAndFlush(any(Product.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
-		//when
-		productCommandService.updateProduct(UUID.randomUUID(),command);
+		// when
+		productCommandService.updateProduct(UUID.randomUUID(), command);
 
-		//then
+		// then
 		verify(productRepository).saveAndFlush(captor.capture());
-		Product saved=captor.getValue();
-		assertThat(saved.getName()).isEqualTo(PRODUCT_NAME);
-		assertThat(saved.getPrice()).isEqualTo(PRICE);
-
+		Product saved = captor.getValue();
+		assertThat(saved.getName()).isEqualTo("newName");
+		assertThat(saved.getPrice()).isEqualTo(200);
 	}
 
 	@Test
-	void 타임딜_설정(){
-		//given
-		Product product = Product.create(PRODUCT_NAME, PRICE, null);
-		UpdateTimeDealCommand command=new UpdateTimeDealCommand(LocalDateTime.now().plusHours(1));
+	void 타임딜_수정_성공() {
+		// given
+		Product product = Product.create(PRODUCT_NAME, PRICE, null, START_TIME, END_TIME);
+		// PENDING_SALE 상태로 설정 (타임딜 수정 가능 상태)
+		ReflectionTestUtils.setField(product, "status", ProductStatus.PENDING_SALE);
 
-		TopicConfig.Product mockProduct = mock(TopicConfig.Product.class);
-		when(topicConfig.getProduct()).thenReturn(mockProduct);
-		when(mockProduct.getCreated()).thenReturn("prod-product-created");
+		LocalDateTime newStart = LocalDateTime.now().plusHours(2);
+		LocalDateTime newEnd = LocalDateTime.now().plusHours(4);
+		UpdateTimeDealCommand command = new UpdateTimeDealCommand(newStart, newEnd);
 
 		when(productRepository.findById(any(UUID.class))).thenReturn(Optional.of(product));
-		when(productRepository.saveAndFlush(any(Product.class))).thenAnswer(invocation -> {
+		when(productRepository.saveAndFlush(any(Product.class))).thenAnswer(invocation ->{
 			Product p = invocation.getArgument(0);
-			ReflectionTestUtils.setField(p, "id", UUID.randomUUID());
-			ReflectionTestUtils.setField(p, "name", PRODUCT_NAME);
-			ReflectionTestUtils.setField(p, "price", PRICE);
+			ReflectionTestUtils.setField(p, "id", UUID.randomUUID()); // id 설정 추가
 			return p;
 		});
-		when(mapper.toCreatedEvent(any(Product.class)))
-			.thenReturn(new ProductCreatedEvent(
-				UUID.randomUUID(),
-				"testName",
-				100,
-				LocalDateTime.now().plusHours(1),
-				UUID.randomUUID()
 
-			));
+		// when
+		productCommandService.updateTimeDeal(UUID.randomUUID(), command);
 
-		//when
-		productCommandService.updateTimeDeal(UUID.randomUUID(),command);
-
-		//then
+		// then
 		verify(productRepository).saveAndFlush(captor.capture());
-		Product saved=captor.getValue();
-		assertThat(saved.getTimeDealSchedule()).isNotNull();
+		Product saved = captor.getValue();
+		assertThat(saved.getTimeDealSchedule().getStartTime()).isEqualTo(newStart);
+		assertThat(saved.getTimeDealSchedule().getEndTime()).isEqualTo(newEnd);
+		assertThat(saved.getStatus()).isEqualTo(ProductStatus.PENDING_RESERVATION);
+		verify(schedulerService).rescheduleTimeDealStart(any(UUID.class), any(LocalDateTime.class));
 	}
 
 	@Test
-	void 판매취소(){
-		//given
-		Product product = Product.create(PRODUCT_NAME, PRICE, null);
+	void 판매취소() {
+		// given
+		Product product = Product.create(PRODUCT_NAME, PRICE, null, START_TIME, END_TIME);
 		when(productRepository.findById(any(UUID.class))).thenReturn(Optional.of(product));
 
-		//when
+		// when
 		productCommandService.cancelSale(UUID.randomUUID());
 
-		//then
+		// then
 		assertThat(product.getStatus()).isEqualTo(ProductStatus.SALE_CANCELED);
+		verify(schedulerService).cancelSchedule(any(UUID.class));
 	}
 }

--- a/src/test/java/org/pgsg/product/application/service/ProductCommandServiceTest.java
+++ b/src/test/java/org/pgsg/product/application/service/ProductCommandServiceTest.java
@@ -124,7 +124,7 @@ class ProductCommandServiceTest {
 	}
 
 	@Test
-	void updateProduct() {
+	void updateInfoProduct() {
 		//given
 		Product product = Product.create(PRODUCT_NAME, PRICE, null);
 		UpdateProductCommand command=new UpdateProductCommand("test",1,null,LocalDateTime.now(),LocalDateTime.now().plusHours(1));
@@ -177,7 +177,7 @@ class ProductCommandServiceTest {
 			));
 
 		//when
-		productCommandService.setTimeDeal(UUID.randomUUID(),command);
+		productCommandService.updateTimeDeal(UUID.randomUUID(),command);
 
 		//then
 		verify(productRepository).saveAndFlush(captor.capture());

--- a/src/test/java/org/pgsg/product/domain/model/ProductTest.java
+++ b/src/test/java/org/pgsg/product/domain/model/ProductTest.java
@@ -30,7 +30,7 @@ class ProductTest {
 	@BeforeEach
 	void setUp() {
 		validProduct = Product.create(VALID_PRODUCT_NAME, VALID_PRODUCT_PRICE,VALID_PRODUCT_DESCRIPTION);
-		validProduct.setTimeDealSchedule(LocalDateTime.now().plusHours(3));
+		validProduct.UpdateTimeDealSchedule(LocalDateTime.now().plusHours(3));
 		ReflectionTestUtils.setField(validProduct, "status", ProductStatus.PENDING_RESERVATION);
 
 		securityUtilMockedStatic = mockStatic(SecurityUtil.class);
@@ -75,7 +75,7 @@ class ProductTest {
 	void create_잘못된_종료시간_설정(){
 		Product p=Product
 			.create(VALID_PRODUCT_NAME, VALID_PRODUCT_PRICE,VALID_PRODUCT_DESCRIPTION);
-		assertThatThrownBy(()->p.setTimeDealSchedule(LocalDateTime.now()))
+		assertThatThrownBy(()->p.UpdateTimeDealSchedule(LocalDateTime.now()))
 			.isInstanceOf(CustomException.class);
 	}
 
@@ -114,8 +114,8 @@ class ProductTest {
 	}
 
 	@Test
-	void update() {
-		validProduct.update("new",null,null,null);
+	void updateInfo() {
+		validProduct.updateInfo("new",null,null,null);
 		assertThat(validProduct.getName()).isEqualTo("new");
 		assertThat(validProduct.getPrice()).isEqualTo(VALID_PRODUCT_PRICE);
 		assertThat(validProduct.getDescription()).isEqualTo(VALID_PRODUCT_DESCRIPTION);
@@ -124,7 +124,7 @@ class ProductTest {
 	@Test
 	void changeTimeDealSchedule() {
 		TimeDealSchedule newSchedule=TimeDealSchedule.of(LocalDateTime.now().plusHours(2),LocalDateTime.now().plusHours(3));
-		validProduct.update(null,null,null,newSchedule);
+		validProduct.updateInfo(null,null,null,newSchedule);
 		assertThat(validProduct.getName()).isEqualTo(VALID_PRODUCT_NAME);
 		assertThat(validProduct.getPrice()).isEqualTo(VALID_PRODUCT_PRICE);
 		assertThat(validProduct.getDescription()).isEqualTo(VALID_PRODUCT_DESCRIPTION);

--- a/src/test/java/org/pgsg/product/domain/model/ProductTest.java
+++ b/src/test/java/org/pgsg/product/domain/model/ProductTest.java
@@ -23,18 +23,22 @@ class ProductTest {
 	private static final String VALID_PRODUCT_NAME = "Test Product";
 	private static final String VALID_PRODUCT_DESCRIPTION = "Test Product";
 	private static final Integer VALID_PRODUCT_PRICE = 100;
-	private MockedStatic<SecurityUtil> securityUtilMockedStatic;
+	private static final LocalDateTime VALID_START_TIME = LocalDateTime.now().plusHours(1);
+	private static final LocalDateTime VALID_END_TIME = LocalDateTime.now().plusHours(3);
 
+	private MockedStatic<SecurityUtil> securityUtilMockedStatic;
 	private Product validProduct;
 
 	@BeforeEach
 	void setUp() {
-		validProduct = Product.create(VALID_PRODUCT_NAME, VALID_PRODUCT_PRICE,VALID_PRODUCT_DESCRIPTION);
-		validProduct.UpdateTimeDealSchedule(LocalDateTime.now().plusHours(3));
+		validProduct = Product.create(
+			VALID_PRODUCT_NAME, VALID_PRODUCT_PRICE, VALID_PRODUCT_DESCRIPTION,
+			VALID_START_TIME, VALID_END_TIME
+		);
+		// create() 후 PENDING_RESERVATION 상태이므로 startReserve() 테스트를 위해 그대로 사용
 		ReflectionTestUtils.setField(validProduct, "status", ProductStatus.PENDING_RESERVATION);
 
 		securityUtilMockedStatic = mockStatic(SecurityUtil.class);
-
 		securityUtilMockedStatic.when(SecurityUtil::getCurrentUser)
 			.thenReturn(Optional.of(UserDetailsImpl.builder()
 				.uuid(UUID.randomUUID())
@@ -57,39 +61,69 @@ class ProductTest {
 
 	@Test
 	void create_성공() {
-		Product p = Product.create(VALID_PRODUCT_NAME, VALID_PRODUCT_PRICE,VALID_PRODUCT_DESCRIPTION);
+		Product p = Product.create(
+			VALID_PRODUCT_NAME, VALID_PRODUCT_PRICE, VALID_PRODUCT_DESCRIPTION,
+			VALID_START_TIME, VALID_END_TIME
+		);
 
 		assertThat(p.getName()).isEqualTo(VALID_PRODUCT_NAME);
 		assertThat(p.getPrice()).isEqualTo(VALID_PRODUCT_PRICE);
 		assertThat(p.getDescription()).isEqualTo(VALID_PRODUCT_DESCRIPTION);
+		assertThat(p.getTimeDealSchedule()).isNotNull();
+		assertThat(p.getStatus()).isEqualTo(ProductStatus.PENDING_RESERVATION);
 	}
 
 	@Test
 	void create_잘못된_가격() {
-		assertThatThrownBy(()->Product
-			.create(VALID_PRODUCT_NAME, -1,VALID_PRODUCT_DESCRIPTION))
-			.isInstanceOf(CustomException.class);
+		assertThatThrownBy(() -> Product.create(
+			VALID_PRODUCT_NAME, -1, VALID_PRODUCT_DESCRIPTION,
+			VALID_START_TIME, VALID_END_TIME)
+		).isInstanceOf(CustomException.class);
 	}
 
 	@Test
-	void create_잘못된_종료시간_설정(){
-		Product p=Product
-			.create(VALID_PRODUCT_NAME, VALID_PRODUCT_PRICE,VALID_PRODUCT_DESCRIPTION);
-		assertThatThrownBy(()->p.UpdateTimeDealSchedule(LocalDateTime.now()))
-			.isInstanceOf(CustomException.class);
+	void create_잘못된_시작시간_설정() {
+		assertThatThrownBy(() -> Product.create(
+			VALID_PRODUCT_NAME, VALID_PRODUCT_PRICE, VALID_PRODUCT_DESCRIPTION,
+			LocalDateTime.now().minusHours(1), VALID_END_TIME)
+		).isInstanceOf(CustomException.class);
 	}
 
-	// @Test	//todo: 해당 부분은 스케줄링 고도화 시 다시 작성
-	// void create_잘못된_시작시간_설정(){
-	// 		assertThatThrownBy(()->Product
-	// 		.create(VALID_PRODUCT_NAME, VALID_PRODUCT_PRICE,VALID_PRODUCT_DESCRIPTION,
-	// 			TimeDealSchedule.of(LocalDateTime.now().minusHours(1),LocalDateTime.now().plusHours(1))))
-	// 		.isInstanceOf(CustomException.class);
-	// }
+	@Test
+	void create_잘못된_종료시간_설정() {
+		assertThatThrownBy(() -> Product.create(
+			VALID_PRODUCT_NAME, VALID_PRODUCT_PRICE, VALID_PRODUCT_DESCRIPTION,
+			VALID_START_TIME, VALID_START_TIME.plusMinutes(10))  // 15분 미만
+		).isInstanceOf(CustomException.class);
+	}
 
 	@Test
-	void 타임딜_스케줄링_성공(){
+	void 타임딜_스케줄링_성공() {
 		assertThat(validProduct.getTimeDealSchedule()).isNotNull();
+	}
+
+	@Test
+	void updateTimeDeal_성공() {
+		// PENDING_SALE 상태에서 타임딜 수정
+		ReflectionTestUtils.setField(validProduct, "status", ProductStatus.PENDING_SALE);
+
+		LocalDateTime newStart = LocalDateTime.now().plusHours(2);
+		LocalDateTime newEnd = LocalDateTime.now().plusHours(4);
+		validProduct.updateTimeDeal(newStart, newEnd);
+
+		assertThat(validProduct.getTimeDealSchedule().getStartTime()).isEqualTo(newStart);
+		assertThat(validProduct.getTimeDealSchedule().getEndTime()).isEqualTo(newEnd);
+		assertThat(validProduct.getStatus()).isEqualTo(ProductStatus.PENDING_RESERVATION);
+	}
+
+	@Test
+	void updateTimeDeal_잘못된_상태() {
+		// PENDING_RESERVATION 이외 상태에서 수정 불가
+		ReflectionTestUtils.setField(validProduct, "status", ProductStatus.RESERVING);
+
+		assertThatThrownBy(() -> validProduct.updateTimeDeal(
+			LocalDateTime.now().plusHours(2), LocalDateTime.now().plusHours(4))
+		).isInstanceOf(CustomException.class);
 	}
 
 	@Test
@@ -102,10 +136,9 @@ class ProductTest {
 
 	@Test
 	void 상태_변경_실패() {
-		assertThatThrownBy(()->validProduct.complete())
+		assertThatThrownBy(() -> validProduct.complete())
 			.isInstanceOf(CustomException.class);
 	}
-
 
 	@Test
 	void cancelSale() {
@@ -114,27 +147,16 @@ class ProductTest {
 	}
 
 	@Test
-	void updateInfo() {
-		validProduct.updateInfo("new",null,null,null);
+	void updateInfo_성공() {
+		validProduct.updateInfo("new", null, null);
 		assertThat(validProduct.getName()).isEqualTo("new");
 		assertThat(validProduct.getPrice()).isEqualTo(VALID_PRODUCT_PRICE);
 		assertThat(validProduct.getDescription()).isEqualTo(VALID_PRODUCT_DESCRIPTION);
 	}
 
 	@Test
-	void changeTimeDealSchedule() {
-		TimeDealSchedule newSchedule=TimeDealSchedule.of(LocalDateTime.now().plusHours(2),LocalDateTime.now().plusHours(3));
-		validProduct.updateInfo(null,null,null,newSchedule);
-		assertThat(validProduct.getName()).isEqualTo(VALID_PRODUCT_NAME);
-		assertThat(validProduct.getPrice()).isEqualTo(VALID_PRODUCT_PRICE);
-		assertThat(validProduct.getDescription()).isEqualTo(VALID_PRODUCT_DESCRIPTION);
-		assertThat(validProduct.getTimeDealSchedule().getStartTime()).isEqualTo(newSchedule.getStartTime());
-		assertThat(validProduct.getTimeDealSchedule().getEndTime()).isEqualTo(newSchedule.getEndTime());
-	}
-
-	@Test
 	void deleteProduct() {
-		UUID id=UUID.randomUUID();
+		UUID id = UUID.randomUUID();
 		validProduct.deleteProduct(id);
 		assertThat(validProduct.getDeletedBy()).isEqualTo(id);
 		assertNotNull(validProduct.getDeletedAt());

--- a/test.js
+++ b/test.js
@@ -1,0 +1,22 @@
+import http from 'k6/http';
+import { check } from 'k6';
+
+export const options = {
+    vus: 100,        // 동시 사용자 100명
+    duration: '30s', // 30초 동안 실행
+};
+
+export default function () {
+    const headers = {   //테스트 시 헤더에 추가할 부분
+        'X-User-Id': '41a4106e-2057-49f7-ae9c-6c2ce5e0b995',
+        'X-User-Username': 'test',
+        'X-User-Roles': 'ROLE_USER',
+        'X-User-Enabled': 'true',
+    };
+
+    const res = http.get('http://34.64.205.199:8082/api/v1/products', { headers }); //요청 주소
+
+    check(res, {
+        'status is 200': (r) => r.status === 200,   //응답 성공 여부에 대한 판단 기준
+    });
+}


### PR DESCRIPTION
### 작업 배경
- 타임딜 스케줄링의 고도화를 진행했습니다.

### 작업 내용
- quartz를 도입하여 타임딜을 예약하여 정해진 시간에 시작 이벤트가 발행되도록 구현하였습니다.

### 테스트 여부
- 기존 도메인 및 서비스 테스트를 수정 후 완료하였습니다.

### 이슈
> This closes #22 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 타임딜 시작을 자동으로 예약/재등록/취소하는 스케줄러가 도입되었습니다.

* **기능 변경**
  * 상품 생성 시 타임딜 시작/종료 시간을 반드시 지정해야 합니다.
  * 상품 정보 수정과 타임딜 일정 변경이 분리되어 각각 독립적으로 처리됩니다.
  * 판매 취소/삭제 시 연동된 스케줄이 자동으로 취소됩니다.

* **유효성 검사**
  * 시작시간이 과거인 경우와 최소 기간(15분) 미만인 종료시간에 대한 검증이 강화되었습니다.

* **테스트**
  * 외부 부하(성능) 검증용 스크립트가 추가되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/89-49/product-service/pull/24?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->